### PR TITLE
Add URL to Microsoft Docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # docs-powershell
 
-Repository for powershell hub and powershell module browser for docs.microsoft.com
+Repository for powershell hub and powershell module browser for [docs.microsoft.com](https://docs.microsoft.com)


### PR DESCRIPTION
Modified the README so that "docs.microsoft.com" points to the official Microsoft Documentation website.